### PR TITLE
Pagination Bug

### DIFF
--- a/src/pagination.js
+++ b/src/pagination.js
@@ -51,7 +51,7 @@ export class Pagination extends React.Component {
 
   onSubmit() {
     if (this.isValidPage(this.state.dirtyValue)) {
-      this.props.onChange(this.state.dirtyValue);
+      this.props.onChange(Number(this.state.dirtyValue));
     }
   }
 


### PR DESCRIPTION
No longer getting console error expecting 'number'.
![screen shot 2016-07-15 at 10 00 28 am](https://cloud.githubusercontent.com/assets/16338229/16882348/66c69f1a-4a73-11e6-9eec-618dfbae758a.png)
Fixes pagination so it no longer makes it a string. Number only.